### PR TITLE
Allow classes to be passed to the SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ website](https://phosphoricons.com/) to find icons.
 The render function takes two arguments:
 
 ```clj
-(render id {:size color style})
+(render id {:size :color :style :class})
 ```
 
 All the map options are optional.
@@ -132,6 +132,7 @@ All the map options are optional.
 - `color` is the icon's color. Icons use `currentColor`, so you can also set
   color with CSS in parent elements.
 - `style` is a map of styles for the `svg` element
+- `class` is either a compatible format for specifying CSS classes that your rendering library supports (usually either an array of strings or a space-separated list)
 
 ## License
 

--- a/src/phosphor/icons.cljs
+++ b/src/phosphor/icons.cljs
@@ -9,12 +9,14 @@
 (defn get-loaded-icons []
   (keys @icons))
 
-(defn render [id & [{:keys [size color style]}]]
+(defn render [id & [{:keys [size color style class]}]]
   (if-let [svg (get @icons id)]
-    (assoc-in svg [1 :style] (cond-> {:display "inline-block"
-                                      :line-height "1"}
-                               size (assoc :height size)
-                               size (assoc :width size)
-                               color (assoc :color color)
-                               style (into style)))
+    (cond->
+        (assoc-in svg [1 :style] (cond-> {:display "inline-block"
+                                          :line-height "1"}
+                                   size (assoc :height size)
+                                   size (assoc :width size)
+                                   color (assoc :color color)
+                                   style (into style)))
+      class (assoc-in [1 :class] class))
     (throw (js/Error. (str "Icon " id " is not loaded. Try loading it with `load-icon!`, or check that it exists.")))))


### PR DESCRIPTION
Useful for utility libraries like tailwind where you specify the styling through utility classes